### PR TITLE
Fix: Add support for Icscripthub v4

### DIFF
--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/Addon.json
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/Addon.json
@@ -1,6 +1,6 @@
 {
 	"Name":"BrivGemFarm Briv Feat Swap",
-	"Version": "v1.5.10",
+	"Version": "v1.5.11",
     "Includes" : "IC_BrivGemFarm_BrivFeatSwap_Component.ahk",
     "Author" : "ImpEGamer",
     "Url" : "https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_BrivFeatSwap_Extra",

--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
@@ -1,6 +1,5 @@
 #include %A_LineFile%\..\IC_BrivGemFarm_BrivFeatSwap_Functions.ahk
 #include %A_LineFile%\..\IC_BrivGemFarm_BrivFeatSwap_Overrides.ahk
-#include %A_LineFile%\..\..\..\SharedFunctions\IC_UpdateClass_Class.ahk
 #include *i %A_LineFile%\..\..\..\SharedFunctions\SH_UpdateClass.ahk
 if (IsObject(SH_UpdateClass))
 {

--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
@@ -5,7 +5,7 @@ if (IsObject(SH_UpdateClass))
 {
     	SH_UpdateClass.UpdateClassFunctions(g_BrivGemFarm, IC_BrivGemFarm_BrivFeatSwap_Class, true)
         SH_UpdateClass.UpdateClassFunctions(g_SF,IC_BrivGemFarm_BrivFeatSwap_Class)
-        SH_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class)
+        SH_UpdateClass.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class)
 }
 else
 {

--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
@@ -1,7 +1,19 @@
 #include %A_LineFile%\..\IC_BrivGemFarm_BrivFeatSwap_Functions.ahk
 #include %A_LineFile%\..\IC_BrivGemFarm_BrivFeatSwap_Overrides.ahk
 #include %A_LineFile%\..\..\..\SharedFunctions\IC_UpdateClass_Class.ahk
-IC_UpdateClass_Class.UpdateClassFunctions(g_BrivGemFarm, IC_BrivGemFarm_BrivFeatSwap_Class, true)
-IC_UpdateClass_Class.UpdateClassFunctions(g_SF, IC_BrivGemFarm_BrivFeatSwap_SharedFunctions_Class)
-IC_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class)
+#include *i %A_LineFile%\..\..\..\SharedFunctions\SH_UpdateClass.ahk
+if (IsObject(SH_UpdateClass))
+{
+    	SH_UpdateClass.UpdateClassFunctions(g_BrivGemFarm, IC_BrivGemFarm_BrivFeatSwap_Class, true)
+        SH_UpdateClass.UpdateClassFunctions(g_SF,IC_BrivGemFarm_BrivFeatSwap_Class, true)
+        SH_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class, true)
+}
+else
+{
+    	#include *i %A_LineFile%\..\..\..\SharedFunctions\IC_UpdateClass_Class.ahk
+        IC_UpdateClass_Class.UpdateClassFunctions(g_BrivGemFarm, IC_BrivGemFarm_BrivFeatSwap_Class, true)   
+        IC_UpdateClass_Class.UpdateClassFunctions(g_SF, IC_BrivGemFarm_BrivFeatSwap_SharedFunctions_Class)
+        IC_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class)
+}
+
 g_SharedData.BGFBFS_Init()

--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/IC_BrivGemFarm_BrivFeatSwap_Addon.ahk
@@ -4,8 +4,8 @@
 if (IsObject(SH_UpdateClass))
 {
     	SH_UpdateClass.UpdateClassFunctions(g_BrivGemFarm, IC_BrivGemFarm_BrivFeatSwap_Class, true)
-        SH_UpdateClass.UpdateClassFunctions(g_SF,IC_BrivGemFarm_BrivFeatSwap_Class, true)
-        SH_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class, true)
+        SH_UpdateClass.UpdateClassFunctions(g_SF,IC_BrivGemFarm_BrivFeatSwap_Class)
+        SH_UpdateClass_Class.UpdateClassFunctions(g_SharedData, IC_BrivGemFarm_BrivFeatSwap_IC_SharedData_Class)
 }
 else
 {


### PR DESCRIPTION
Why do we need this change?
=======================
The Scripthub setup went through a refactor for v4 and renamed most of the sharedlibraries. To resolve this and support users on both v3 and v4 do a include and setup based on what version is being used.

What effects does this change have?
=======================
* Adds a conditional include that attempts to load 4 first
* IF that fails load and do version 3 setup
