### PR TITLE
Reverted addon link changes so they now point back to Imp's repo.

### DIFF
--- a/IC_BrivGemFarm_BrivFeatSwap_Extra/Addon.json
+++ b/IC_BrivGemFarm_BrivFeatSwap_Extra/Addon.json
@@ -3,7 +3,7 @@
 	"Version": "v1.6.9",
     "Includes" : "IC_BrivGemFarm_BrivFeatSwap_Component.ahk",
     "Author" : "ImpEGamer",
-    "Url" : "https://github.com/antilectual/IC_Addons-1/tree/Anti-Changes/IC_BrivGemFarm_BrivFeatSwap_Extra",
+    "Url" : "https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_BrivFeatSwap_Extra",
     "Info" : "This Addon will allow to use Briv in E formation so you can take advantage of the \"save feats with formation\" feature to have hybrid jump setups using the Wasting Haste feat (lock at 4J).",
     "Dependencies" : [
         {

--- a/IC_BrivGemFarm_HybridTurboStacking_Extra/Addon.json
+++ b/IC_BrivGemFarm_HybridTurboStacking_Extra/Addon.json
@@ -3,7 +3,7 @@
 	"Version": "v1.2.5",
     "Includes" : "IC_BrivGemFarm_HybridTurboStacking_Includes.ahk",
     "Author" : "ImpEGamer",
-    "Url" : "https://github.com/antilectual/IC_Addons-1/tree/Anti-Changes/IC_BrivGemFarm_HybridTurboStacking_Extra",
+    "Url" : "https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_HybridTurboStacking_Extra",
     "Info" : "This Addon will improve the speed of hybrid stacking during gem farming.",
     "Dependencies" : [
         {

--- a/IC_BrivGemFarm_LevelUp_Extra/Addon.json
+++ b/IC_BrivGemFarm_LevelUp_Extra/Addon.json
@@ -3,7 +3,7 @@
 	"Version": "v1.5.1",
     "Includes" : "IC_BrivGemFarm_LevelUp_Component.ahk",
     "Author" : "ImpEGamer",
-    "Url" : "https://github.com/antilectual/IC_Addons-1/tree/Anti-Changes/IC_BrivGemFarm_LevelUp_Extra",
+    "Url" : "https://github.com/imp444/IC_Addons/tree/main/IC_BrivGemFarm_LevelUp_Extra",
     "Info" : "This Addon will allow to set up maximum champion level settings for BrivGemFarm.",
     "Dependencies" : [
         {

--- a/IC_RNGWaitingRoom_Extra/Addon.json
+++ b/IC_RNGWaitingRoom_Extra/Addon.json
@@ -3,7 +3,7 @@
 	"Version": "v0.3.1",
     "Includes" : "IC_RNGWaitingRoom_Includes.ahk",
     "Author" : "ImpEGamer",
-    "Url" : "https://github.com/antilectual/IC_Addons-1/tree/Anti-Changes/IC_RNGWaitingRoom_Extra",
+    "Url" : "https://github.com/imp444/IC_Addons/tree/main/IC_RNGWaitingRoom_Extra",
     "Info" : "This Addon does things with RNG abilities.",
     "Dependencies" : [
         {


### PR DESCRIPTION
I forgot to change addon links (used for version checking) back to your repo. Correcting that here.